### PR TITLE
Ex4 Collection automated promotion

### DIFF
--- a/.shopify/metafields.json
+++ b/.shopify/metafields.json
@@ -2,7 +2,18 @@
   "article": [],
   "blog": [],
   "brand": [],
-  "collection": [],
+  "collection": [
+    {
+      "key": "badge_title",
+      "namespace": "custom",
+      "name": "Titre badge",
+      "description": "Création d'un badge au nom personnalisé",
+      "type": {
+        "name": "single_line_text_field",
+        "category": "TEXT"
+      }
+    }
+  ],
   "company": [],
   "company_location": [],
   "location": [],

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ shopify theme push
 
 ## Exercice 3 : Utilisation de Shopify CLI et gestion de version
 
-## Exercice 4 : réduction automatique de 10 % sur une collection
+## [Exercice 4](./doc/ex4-collection-automated-promotion.md) : réduction automatique de 10 % sur une collection

--- a/doc/ex4-collection-automated-promotion.md
+++ b/doc/ex4-collection-automated-promotion.md
@@ -1,0 +1,55 @@
+# Exercice 4 : réduction automatique de 10 % sur une collection
+
+## Détection de la collection et application de la remise
+- *Créer une promotion automatique “Soldes” de 10% pour tous les produits appartenant à la collection Promotions.*
+- *Identifier les produits appartenant à la collection ciblée.*
+- *Calculer le prix remisé en appliquant la réduction de 10 % sur le prix d'origine et afficher le nom de la promotion (“Soldes”), en automatique, dans un label.*
+
+**1er essai : promotions**
+Dans le B.O, création d'une collection "Promotions", sur tous les produits ayant un type "snowboard". Puis création d'une promotion de type "Montant réduit sur les produits", nommée "Soldes" : 
+- réduction automatique
+- valeur de réduction : pourcentage -> 10%
+- s'applique à la collection Promotions
+- aucune exigence d'achat minimale
+- cumul : tout
+--> l'ancien et le nouveau prix, ainsi que le nom de la promotion s'affichent uniquement dans le panier. Le pourcentage de réduction ne s'affiche pas.
+
+Problème rencontré : j'ai passé beaucoup de temps à chercher comment afficher ces promotions. Par exemple, dans card-product.liquid, je ne rentrais jamais dans la condition suivante, alors que mon produit était bien concerné par une promotion : 
+```php 
+elsif card_product.compare_at_price > card_product.price and card_product.available -%}
+```
+J'ai perdu beaucoup de temps avant d'apprendre que les remises automatiques ne sont appliquées que dans le panier, et ne sont donc pas disponible sur la fiche ou la carte produit. C'est là que j'ai découvert les metafields.
+
+**2ème essai : metafields**
+1. Création d'un metafield de collection : "Titre badge", de type "Texte sur une seule ligne".
+2. Création de la collection "Promotions", à laquelle je donne le Titre Badge de "Soldes".
+3. Création d'une réduction "Soldes" de type "Montant réduit sur les produits", qui s'applique sur les produits de la collection Promotions
+
+
+## Affichage du prix barré et du prix remisé
+- *Sur la fiche produit et sur les pages de collection, afficher le prix d'origine barré et le prix remisé à côté.*
+- *S'assurer que le format d'affichage reste cohérent et lisible, en utilisant les bonnes pratiques de Shopify et en respectant le style du thème.*
+- *S’assurer que le label change en cas de changement du nom de la promotion automatique.*
+- *S’assurer que la remise change en cas de changement du pourcentage de la remise dans la promotion automatique.*
+
+Malgré l'utilisation des metafields, il m'est toujours impossible d'afficher le prix réduit et le badge "Soldes" sur la fiche produit via les différents templates (price.liquid, card-product.liquid, cart-drawer.liquid..). J'ai même recopié/adapté le code d'un autre candidat, sans succès.
+Je ne comprends pas, est-ce qu'il y aurait un paramétrage que j'aurai manqué ?
+Le forum de Shopify n'est accessible qu'avec un compte payant.
+
+J'ai enfin réussi à affiché le badge "Soldes" sur la fiche et la carte produit. La découverte d'un équivalent à var_dump pour liquid m'a beaucoup aidé : ``` {{ c | json }} ```
+En inspectant le HTML, je voyais bien que le badge était là, mais n'apparaissait pas, à cause de la classe 'price__badge-sale' qui était en 'display:none;'. J'ai enlevé la classe car je n'ai pas trouvé comment activer l'affichage des badges.
+
+
+## Mise à jour dynamique lors de l'ajout au panier
+- *Vérifier que lorsque le produit est ajouté au panier, le prix remisé est bien pris en compte dans le résumé du panier et que le prix d'origine est toujours affiché comme barré (le cas échéant).*
+
+Avec l'utilisation des metafields, la promotion est bien appliquée dans le panier. Le prix d'origine est barré, et l'étiquette "Soldes" est affichée. Idem lors du paiement.
+
+
+## Performance et maintenabilité
+- *Optimiser le code pour ne pas impacter les performances du site.*
+- *Commenter la logique d'intégration afin de faciliter la maintenance.*
+
+Fichiers modifiés :
+[price.liquid](../snippets/price.liquid)
+[card-product.liquid](../snippets/card-product.liquid)

--- a/doc/ex4-collection-automated-promotion.md
+++ b/doc/ex4-collection-automated-promotion.md
@@ -37,7 +37,7 @@ Je ne comprends pas, est-ce qu'il y aurait un paramétrage que j'aurai manqué ?
 Le forum de Shopify n'est accessible qu'avec un compte payant.
 
 J'ai enfin réussi à affiché le badge "Soldes" sur la fiche et la carte produit. La découverte d'un équivalent à var_dump pour liquid m'a beaucoup aidé : ``` {{ c | json }} ```
-En inspectant le HTML, je voyais bien que le badge était là, mais n'apparaissait pas, à cause de la classe 'price__badge-sale' qui était en 'display:none;'. J'ai enlevé la classe car je n'ai pas trouvé comment activer l'affichage des badges.
+En inspectant le HTML, je voyais bien que le badge était là, mais n'apparaissait pas, à cause de la classe 'price__badge-sale' qui était en 'display:none;'. J'ai enlevé la classe car je n'ai pas trouvé comment activer l'affichage des badges dans le B.O. Par contre le prix affiché est toujours le prix d'origine, le prix remisé n'est pas disponible. Quand j'ajoute '.json' à l'URL, je ne vois pas le prix remisé dans l'array.
 
 
 ## Mise à jour dynamique lors de l'ajout au panier

--- a/snippets/card-product.liquid
+++ b/snippets/card-product.liquid
@@ -124,7 +124,18 @@
               </a>
             </h3>
           </div>
+
           <div class="card__badge {{ settings.badge_position }}">
+            {% # On parcourt les collections associées au produit : si elles ont le metafield correspondant à nos promotions, on l'affiche %}
+            {%- for c in card_product.collections -%}
+              {%- if c.metafields.custom.badge_title != blank and c.metafields.custom.badge_title != '' -%}
+                <span class="badge color-{{ settings.sale_badge_color_scheme }}">
+                  {{ c.metafields.custom.badge_title }}
+                </span>
+              {%- endif -%}
+            {%- endfor -%}
+
+            {% # Si le produit est indisponible %}
             {%- if card_product.available == false -%}
               <span
                 id="NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
@@ -132,12 +143,14 @@
               >
                 {{- 'products.product.sold_out' | t -}}
               </span>
-            {%- elsif card_product.compare_at_price > card_product.price and card_product.available -%}
+
+              {% # Si le prix est réduit %}
+            {%- elsif card_product.compare_at_price > card_product.price -%}
               <span
                 id="NoMediaStandardBadge-{{ section_id }}-{{ card_product.id }}"
                 class="badge badge--bottom-left color-{{ settings.sale_badge_color_scheme }}"
               >
-                {{- 'products.product.on_sale' | t -}}
+                {{ 'products.product.on_sale' | t }}
               </span>
             {%- endif -%}
           </div>
@@ -206,7 +219,7 @@
 
             {% render 'price', product: card_product, price_class: '', show_compare_at_price: true %}
             {%- if card_product.quantity_price_breaks_configured? -%}
-              {% if card_product.variants_count == 1 and quick_add == 'bulk' %}
+              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
                 {% liquid
                   assign quantity_rule = card_product.selected_or_first_available_variant.quantity_rule
                   assign has_qty_rules = false
@@ -226,7 +239,7 @@
                   <span class="caption">{{ 'products.product.volume_pricing.note' | t }}</span>
                 </div>
               {% endif %}
-              {% if card_product.variants_count == 1 and quick_add == 'bulk' %}
+              {% if card_product.variants.size == 1 and quick_add == 'bulk' %}
                 <div
                   class="global-settings-popup quantity-popover__info"
                   tabindex="-1"
@@ -297,7 +310,7 @@
                 assign qty_rules = true
               endif
             -%}
-            {%- if card_product.variants_count > 1 or qty_rules -%}
+            {%- if card_product.variants.size > 1 or qty_rules -%}
               <modal-opener data-modal="#QuickAdd-{{ card_product.id }}">
                 <button
                   id="{{ product_form_id }}-submit"
@@ -389,7 +402,7 @@
             {%- endif -%}
           </div>
         {% elsif quick_add == 'bulk' %}
-          {% if card_product.variants_count == 1 %}
+          {% if card_product.variants.size == 1 %}
             <quick-add-bulk
               data-min="{{ card_product.selected_or_first_available_variant.quantity_rule.min }}"
               id="quick-add-bulk-{{ card_product.selected_or_first_available_variant.id }}-{{ section.id }}"

--- a/snippets/price.liquid
+++ b/snippets/price.liquid
@@ -124,13 +124,26 @@
       </small>
     </div>
     {%- if show_badges -%}
-      <span class="badge price__badge-sale color-{{ settings.sale_badge_color_scheme }}">
-        {{ 'products.product.on_sale' | t }}
-      </span>
+      {% # On parcourt les collections associées au produit : si elles ont le metafield correspondant à nos promotions, on l'affiche %}
+      {%- for c in product.collections -%}
+        {%- if c.metafields.custom.badge_title != blank and c.metafields.custom.badge_title != '' -%}
+          <span class="badge color-{{ settings.sale_badge_color_scheme }}">
+            {{ c.metafields.custom.badge_title }}
+          </span>
+        {%- endif -%}
+      {%- endfor -%}
 
-      <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
-        {{ 'products.product.sold_out' | t }}
-      </span>
+      {%- if product.compare_at_price > product.price -%}
+        <span class="badge color-{{ settings.sale_badge_color_scheme }}">
+          {{ 'products.product.on_sale' | t }}
+        </span>
+      {%- endif -%}
+
+      {%- unless product.available -%}
+        <span class="badge price__badge-sold-out color-{{ settings.sold_out_badge_color_scheme }}">
+          {{ 'products.product.sold_out' | t }}
+        </span>
+      {%- endunless -%}
     {%- endif -%}
   </div>
 {% endunless %}


### PR DESCRIPTION
Une promotion de 10% est ajouté à une collection. Le badge "Soldes" apparaît bien, mais pas le nouveau prix. L'ancien prix n'est pas barré.